### PR TITLE
fix: correct run_time_limit default unit (seconds → minutes)

### DIFF
--- a/metaflow_extensions/slurm_ext/plugins/slurm/slurm_cli.py
+++ b/metaflow_extensions/slurm_ext/plugins/slurm/slurm_cli.py
@@ -74,8 +74,8 @@ def slurm():
 )
 @click.option(
     "--run-time-limit",
-    default=5 * 24 * 60 * 60,  # Default is set to 5 days
-    help="Run time limit in seconds for Slurm job.",
+    default=5 * 24 * 60,  # Default is set to 5 days (in minutes, as SLURM interprets bare integers as minutes)
+    help="Run time limit in minutes for Slurm job.",
 )
 @click.pass_context
 def step(


### PR DESCRIPTION
## Summary
Fix incorrect default value for `run_time_limit` — was set in seconds 
but SLURM interprets bare integers as minutes, resulting in a 300-day 
default instead of 5 days.

## Context / Motivation
`run_time_limit` default was `5 * 24 * 60 * 60 = 432000` with comment 
"Default is set to 5 days". SLURM's `--time` interprets bare integers 
as **minutes**, so 432000 minutes = 300 days.

Ref: https://slurm.schedmd.com/sbatch.html#OPT_time

## Changes Made
- Changed default from `5 * 24 * 60 * 60` (432000) to `5 * 24 * 60` (7200)
- Updated help string from "seconds" to "minutes"
- Updated inline comment to clarify unit

## Testing
No automated test added — this corrects a constant default value,
verified against SLURM sbatch documentation.
Manually verified: 5 * 24 * 60 = 7200 minutes = 5 days ✓

## Trade-offs / Design Decisions
Single-line change. Existing users with custom `run_time_limit` values 
are unaffected — only the default changes.
