### PR TITLE
fix: raise clear error when required SSH connection params are None

### DIFF
--- a/metaflow_extensions/slurm_ext/plugins/slurm/slurm_client.py
+++ b/metaflow_extensions/slurm_ext/plugins/slurm/slurm_client.py
@@ -38,6 +38,17 @@ class SlurmClient(object):
                 % sys.executable
             )
 
+        for param, env_var in [
+            ("ssh_key_file", "METAFLOW_SLURM_SSH_KEY_FILE"),
+            ("username", "METAFLOW_SLURM_USERNAME"),
+            ("address", "METAFLOW_SLURM_ADDRESS"),
+        ]:
+            if locals()[param] is None:
+                raise SlurmException(
+                    "%s is required. Set it via @slurm(%s=...) "
+                    "or the %s environment variable." % (param, param, env_var)
+                )
+
         ssh_key_file_path = Path(ssh_key_file).expanduser().resolve()
         cert_file_path = Path(cert_file).expanduser().resolve() if cert_file else None
 


### PR DESCRIPTION
## Summary
Add validation for required SSH connection parameters — previously 
crashed with confusing TypeError if any were None.

## Context / Motivation
If a user forgets to set ssh_key_file, username, or address via 
@slurm(...) or environment variables, the code crashed with:
`TypeError: argument should be str or an os.PathLike object, not NoneType`

This gives no indication of what went wrong or how to fix it.

## Changes Made
- Added validation in `__init__` before first parameter use
- Raises `SlurmException` with clear message for each missing param
- Example: "ssh_key_file is required. Set it via @slurm(ssh_key_file=...) 
  or the METAFLOW_SLURM_SSH_KEY_FILE environment variable."

## Testing
Manually verified: instantiating SlurmClient with None values now 
raises SlurmException with correct message instead of TypeError.

