### PR TITLE
fix: replace bare except with except Exception in task_finished

### DIFF
--- a/metaflow_extensions/slurm_ext/plugins/slurm/slurm_decorator.py
+++ b/metaflow_extensions/slurm_ext/plugins/slurm/slurm_decorator.py
@@ -206,7 +206,7 @@ class SlurmDecorator(StepDecorator):
 
         try:
             self._save_logs_sidecar.terminate()
-        except:
+        except Exception:
             # Best effort kill
             pass
 


### PR DESCRIPTION
## Summary
Replace bare `except:` with `except Exception:` in task_finished 
cleanup block to avoid silently swallowing SystemExit and KeyboardInterrupt.

## Context / Motivation
A bare `except:` catches ALL exceptions including SystemExit, 
KeyboardInterrupt, and GeneratorExit. This means a Ctrl+C during 
cleanup would be silently swallowed, making the process appear hung.

## Changes Made
- Changed `except:` to `except Exception:` on line 209 of slurm_decorator.py
- SystemExit and KeyboardInterrupt now propagate correctly

## Testing
No automated test — single line change, behavior verified by code inspection.

