### PR TITLE
fix: replace bare except with except Exception in task_finished

### DIFF
--- a/metaflow_extensions/slurm_ext/plugins/slurm/slurm_decorator.py
+++ b/metaflow_extensions/slurm_ext/plugins/slurm/slurm_decorator.py
@@ -206,7 +206,7 @@ class SlurmDecorator(StepDecorator):
 
         try:
             self._save_logs_sidecar.terminate()
-        except:
+        except Exception:
             # Best effort kill
             pass
 


### PR DESCRIPTION
## Problem
In `slurm_decorator.py`, the `task_finished` method 
uses a bare `except:` clause when terminating the 
log sidecar:

try:
    self._save_logs_sidecar.terminate()
except:
    # Best effort kill
    pass

A bare `except:` catches everything including 
`KeyboardInterrupt` and `SystemExit` which should 
never be silently ignored.

## Fix
Replace bare `except:` with `except Exception:` 
which only catches actual exceptions and lets 
system signals pass through correctly.

## Testing
Manually verified the change does not affect 
normal execution flow.