### PR TITLE
fix: remove leftover test code with hardcoded credentials from slurm_client.py

### DIFF
--- a/metaflow_extensions/slurm_ext/plugins/slurm/slurm_client.py
+++ b/metaflow_extensions/slurm_ext/plugins/slurm/slurm_client.py
@@ -138,36 +138,3 @@ class SlurmClient(object):
         proc = await self.conn.run(cmd_scancel)
         if proc.returncode != 0:
             raise RuntimeError(proc.stderr.strip())
-
-
-async def main():
-
-    sc = SlurmClient(
-        username="ubuntu",
-        address="18.236.81.10",
-        ssh_key_file="~/Desktop/outerbounds/parallelcluster/madhur-slurm.pem",
-    )
-    await sc.connect()
-
-    script_contents = """
-#!/bin/bash
-#SBATCH --job-name=python_job        # Job name
-#SBATCH --output=python_job.out      # Standard output log
-#SBATCH --error=python_job.err       # Standard error log
-#SBATCH --time=00:10:00              # Walltime
-#SBATCH --partition=queue1           # Partition name
-#SBATCH --nodes=1                    # Number of nodes
-#SBATCH --ntasks=1                   # Number of tasks
-#SBATCH --cpus-per-task=4            # Number of CPU cores per task
-#SBATCH --mem=4G                     # Memory per node
-
-# Run the Python script
-srun python compute_np.py
-""".strip()
-
-    jid = await sc.submit("madhur", script_contents)
-    print("id: %s" % jid)
-
-
-if __name__ == "__main__":
-    asyncio.run(main())


### PR DESCRIPTION
## Problem
At the bottom of `slurm_client.py` there is a 
leftover `main()` function that was used during 
development for manual testing. It contains:

- Hardcoded server IP address: `18.236.81.10`
- Developer's personal SSH key path:
  `~/Desktop/outerbounds/parallelcluster/madhur-slurm.pem`
- Hardcoded username: `ubuntu`

This code is never called by Metaflow — it only 
runs if `slurm_client.py` is executed directly 
via `if __name__ == "__main__"`. It serves no 
purpose in production and should be removed.

## Changes
- Removed `async def main()` function
- Removed `if __name__ == "__main__"` block
- No changes to any production code or functionality

## Testing
All existing functionality of `SlurmClient` class 
is completely unaffected as `main()` was never 
called by Metaflow internally.