### PR TITLE
Fix shell escaping for Slurm env var values

### DIFF
--- a/metaflow_extensions/slurm_ext/plugins/slurm/slurm_script.py
+++ b/metaflow_extensions/slurm_ext/plugins/slurm/slurm_script.py
@@ -1,7 +1,7 @@
 import uuid
 from string import Template
 from typing import Dict, Optional
-
+from shlex import quote
 
 SLURM_JOB_SCRIPT_TEMPLATE = """\
 #!/bin/bash
@@ -97,11 +97,7 @@ class SlurmJobScript(object):
             "source %s" % self.bashrc_path if self.bashrc_path else "",
         ]
         for key, value in self.env_vars.items():
-            if key == "METAFLOW_INIT_SCRIPT":
-                # this needs outer double quotes
-                setup_lines.append('export %s="%s"' % (key, value))
-            else:
-                setup_lines.append("export %s='%s'" % (key, value))
+            setup_lines.append("export %s=%s" % (key, quote(str(value))))
         return "\n".join(setup_lines)
 
     def get_run_command(


### PR DESCRIPTION
## Summary
Fix shell escaping for environment variable values in generated Slurm job scripts.

## Context 
Fixes #17 

`SlurmJobScript.shell_env_setup` interpolates env var values directly into single-quoted shell strings. Values containing a single quote produce invalid shell syntax and can break Slurm job startup.

## Changes Made
- shell-escape env var values when rendering `export` lines

Before fix, it looked like:
```python
export MY_VAR='O'Reilly'
```

After fix, it looks like:
```python
export MY_VAR='O'"'"'Reilly'
```

## Testing
- Manually reproduced the bug by generating a script with `{"MY_VAR": "O'Reilly"}`
- Verified the generated script is shell-safe after the fix
